### PR TITLE
MainMenu should be visible for Reporting

### DIFF
--- a/src/app/reporting/rpt-context.tsx
+++ b/src/app/reporting/rpt-context.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import { MainMenu } from "@/features/menu/menu";
 
 export const RptContext = () => {
-    const [isOpen, setIsOpen] = useState(false);
+    const [isOpen, setIsOpen] = useState(true);
     return (
         <MainMenu isOpen={isOpen} setIsOpen={setIsOpen} />
     )


### PR DESCRIPTION
Minor fix: making the left menu visible for the reporting view.

![image](https://github.com/oliverlabs/azurechatgpt/assets/3272563/788fd798-df79-4939-9243-c63f26a284e2)
